### PR TITLE
Trying to improve the Klement-solver

### DIFF
--- a/src/broyden.jl
+++ b/src/broyden.jl
@@ -16,7 +16,7 @@ function SciMLBase.solve(prob::NonlinearProblem,
     x = float(prob.u0)
     fₙ = f(x)
     T = eltype(x)
-    J⁻¹ = ArrayInterfaceCore.zeromatrix(x) + I
+    J⁻¹ = init_J(x)
 
     if SciMLBase.isinplace(prob)
         error("Broyden currently only supports out-of-place nonlinear problems")

--- a/src/klement.jl
+++ b/src/klement.jl
@@ -5,8 +5,6 @@ Klement()
 
 A low-overhead implementation of [Klement](https://jatm.com.br/jatm/article/view/373).
 This method is non-allocating on scalar and static array problems.
-
-
 """
 struct Klement <: AbstractSimpleNonlinearSolveAlgorithm end
 
@@ -32,7 +30,6 @@ function SciMLBase.solve(prob::NonlinearProblem,
     xₙ₋₁ = x
     fₙ₋₁ = fₙ
     for _ in 1:maxiters
-
         xₙ = xₙ₋₁ - inv(J) * fₙ₋₁
         fₙ = f(xₙ)
         Δxₙ = xₙ - xₙ₋₁

--- a/src/klement.jl
+++ b/src/klement.jl
@@ -34,8 +34,7 @@ function SciMLBase.solve(prob::NonlinearProblem,
     if isa(x, Number)
         J = 1.0
         for _ in 1:maxiters
-
-            xₙ = xₙ₋₁ - fₙ₋₁/J
+            xₙ = xₙ₋₁ - fₙ₋₁ / J
             fₙ = f(xₙ)
 
             iszero(fₙ) &&
@@ -51,7 +50,7 @@ function SciMLBase.solve(prob::NonlinearProblem,
             Δfₙ = fₙ - fₙ₋₁
 
             # Prevent division by 0
-            denominator = max(J ^ 2 * Δxₙ ^ 2, 1e-9)
+            denominator = max(J^2 * Δxₙ^2, 1e-9)
 
             k = (Δfₙ - J * Δxₙ) / denominator
             J += (k * Δxₙ * J) * J
@@ -64,7 +63,7 @@ function SciMLBase.solve(prob::NonlinearProblem,
             xₙ₋₁ = xₙ
             fₙ₋₁ = fₙ
         end
-    # x is a vector
+        # x is a vector
     else
         J = init_J(x)
         F = lu(J, check = false)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -33,3 +33,13 @@ value_derivative(f::F, x::AbstractArray) where {F} = f(x), ForwardDiff.jacobian(
 value(x) = x
 value(x::Dual) = ForwardDiff.value(x)
 value(x::AbstractArray{<:Dual}) = map(ForwardDiff.value, x)
+
+function init_J(x)
+    J = ArrayInterfaceCore.zeromatrix(x)
+    if ismutable(x)
+        J[diagind(J)] .= one(eltype(x))
+    else
+        J += I
+    end
+    return J
+end


### PR DESCRIPTION
Trying to solve https://github.com/SciML/SimpleNonlinearSolve.jl/issues/20 and https://github.com/SciML/SimpleNonlinearSolve.jl/issues/19.
I tried the approach described in https://github.com/SciML/SimpleNonlinearSolve.jl/pull/18

But I have not used the singularity test @YingboMa explained:
"Or ```F = lu(J)```, and the singularity check is then ```abs(F.factors[end, end]) < singular_tol```"
Although that solution was faster I was afraid that the LU-decomposition ```lu(J)``` could result in an error if ```J``` was singular.

Therefore I read about good approaches to checking for a singular matrix and found that
```
cond(J) > tolerance_value
```
was a good approach (https://stackoverflow.com/questions/13145948/how-to-find-out-if-a-matrix-is-singular and https://discourse.julialang.org/t/checking-for-singularity-of-matrix/54746/4)

Is this OK, or do you want me to change something?
