### PR TITLE
Remove unnecessary @show

### DIFF
--- a/src/raphson.jl
+++ b/src/raphson.jl
@@ -80,6 +80,5 @@ function SciMLBase.solve(prob::NonlinearProblem,
         xo = x
     end
 
-    @show x, fx
     return SciMLBase.build_solution(prob, alg, x, fx; retcode = ReturnCode.MaxIters)
 end


### PR DESCRIPTION
This PR removes unnecessary `@show` in `solve()` for `SimpleNewtonRaphson`, which was probably introduced during debugging.  Under certain conditions, this `@show` prints out `x` and `fx`, contaminating `stdout`.