### PR TITLE
Updated halley's method for multivariate functions

### DIFF
--- a/src/halley.jl
+++ b/src/halley.jl
@@ -42,6 +42,7 @@ function SciMLBase.__solve(prob::NonlinearProblem,
                            maxiters = 1000, kwargs...)
     f = Base.Fix2(prob.f, prob.p)
     x = float(prob.u0)
+    fx = f(x)
     if isa(x, AbstractArray)
         n = length(x)
     end
@@ -70,7 +71,7 @@ function SciMLBase.__solve(prob::NonlinearProblem,
             else
                 fx = f(x)
                 dfx = ForwardDiff.jacobian(f, x)
-                d2fx = ForwardDiff.jacobian(x -> ForwardDiff.jacobian(f, x), x) #  n^2 by n matrix
+                d2fx = ForwardDiff.jacobian(x -> ForwardDiff.jacobian(f, x), x)
                 ai = -(dfx \ fx)
                 A = reshape(d2fx * ai, (n, n))
                 bi = (dfx) \ (A * ai)


### PR DESCRIPTION
@ChrisRackauckas I have added the multivariate version. However, seems like this method has become allocating. A major change that I did (and I am not sure if it's good) is that I defined the expressions for the first-order and second-order derivatives at the beginning for all cases (`line 45-66` in `src/halley.jl`). I am not really sure what's making it allocating. Is it due to this change I made or due to a matrix addition for storing the 3-dim hessian?