### PR TITLE
Add more tests to Alefeld and fix bugs

### DIFF
--- a/src/alefeld.jl
+++ b/src/alefeld.jl
@@ -18,12 +18,16 @@ function SciMLBase.solve(prob::IntervalNonlinearProblem,
     c = a - (b - a) / (f(b) - f(a)) * f(a)
     
     fc = f(c)
-    if iszero(fc)
+    (a == c || b == c) && 
+        return SciMLBase.build_solution(prob, alg, c, fc;
+                                        retcode = ReturnCode.FloatingPointLimit,
+                                        left = a, 
+                                        right = b)
+    iszero(fc) &&
         return SciMLBase.build_solution(prob, alg, c, fc;
                                         retcode = ReturnCode.Success, 
                                         left = a,
                                         right = b)
-    end
     a, b, d = _bracket(f, a, b, c)
     e = zero(a)   # Set e as 0 before iteration to avoid a non-value f(e)
 

--- a/test/basictests.jl
+++ b/test/basictests.jl
@@ -225,6 +225,18 @@ end
 f, tspan = (u, p) -> p[1] * u * u - p[2], (1.0, 100.0)
 t = (p) -> [sqrt(p[2] / p[1])]
 p = [0.9, 50.0]
+g = function (p)
+    probN = IntervalNonlinearProblem{false}(f, tspan, p)
+    sol = solve(probN, Alefeld())
+    return [sol.u]
+end
+
+@test g(p) ≈ [sqrt(p[2] / p[1])]
+@test ForwardDiff.jacobian(g, p) ≈ ForwardDiff.jacobian(t, p)
+
+f, tspan = (u, p) -> p[1] * u * u - p[2], (1.0, 100.0)
+t = (p) -> [sqrt(p[2] / p[1])]
+p = [0.9, 50.0]
 for alg in [Bisection(), Falsi(), Ridder(), Brent()]
     global g, p
     g = function (p)
@@ -288,6 +300,7 @@ probB = IntervalNonlinearProblem(f, tspan)
 sol = solve(probB, Falsi())
 @test sol.left ≈ sqrt(2.0)
 
+# Bisection
 sol = solve(probB, Bisection())
 @test sol.left ≈ sqrt(2.0)
 
@@ -314,6 +327,18 @@ tspan = (0.0, sqrt(2.0))
 probB = IntervalNonlinearProblem(f, tspan)
 sol = solve(probB, Brent())
 @test sol.left ≈ sqrt(2.0)
+
+# Alefeld
+sol = solve(probB, Alefeld())
+@test sol.u ≈ sqrt(2.0)
+tspan = (sqrt(2.0), 10.0)
+probB = IntervalNonlinearProblem(f, tspan)
+sol = solve(probB, Alefeld())
+@test sol.u ≈ sqrt(2.0)
+tspan = (0.0, sqrt(2.0))
+probB = IntervalNonlinearProblem(f, tspan)
+sol = solve(probB, Alefeld())
+@test sol.u ≈ sqrt(2.0)
 
 # Garuntee Tests for Bisection
 f = function (u, p)


### PR DESCRIPTION
Here are some new things added to the repository:

1. The early version of Alefeld is unable to pass the test when the interval [a, b] is such that either a or b is already a solution. To address this, a new build solution function has been added before the start of iteration.
2. More tests have been added to verify Alefeld, and all tests have passed. The remaining failed cases appear to stem from basictests.jl, specifically lines 489 and 490(Batched Broyden).