### PR TITLE
Fix ITP for problems with flipped sign

### DIFF
--- a/src/itp.jl
+++ b/src/itp.jl
@@ -113,10 +113,11 @@ function SciMLBase.solve(prob::IntervalNonlinearProblem, alg::ITP,
 
         ## Update ##
         yp = f(xp)
-        if yp > 0
+        yps = yp * sign(fr)
+        if yps > 0
             right = xp
             fr = yp
-        elseif yp < 0
+        elseif yps < 0
             left = xp
             fl = yp
         else

--- a/test/basictests.jl
+++ b/test/basictests.jl
@@ -539,3 +539,19 @@ for alg in (SimpleNewtonRaphson(), SimpleTrustRegion())
     sol = solve(probN, alg)
     @test abs.(sol.u) ≈ sqrt.(p)
 end
+
+# Flipped signs test
+f1(u, p) = u * u - p 
+f2(u, p) = p - u * u
+
+for Alg in (Alefeld, Bisection, Falsi, Brent, ITP, Ridder)
+    alg = Alg()
+    for p ∈ 1:4
+        inp1 = IntervalNonlinearProblem(f1, (1.0, 2.0), p)
+        inp2 = IntervalNonlinearProblem(f2, (1.0, 2.0), p)
+        sol = solve(inp1, alg)
+        @test abs.(sol.u) ≈ sqrt.(p)
+        sol = solve(inp2, alg)
+        @test abs.(sol.u) ≈ sqrt.(p)
+    end
+end


### PR DESCRIPTION
For some problems, there's a potential bug as the current ITP implementation follows the pseudocode in the Oliveira - Takahashi paper, which assumes f(left)  < 0 < f(right), and thus it may wrongly contract the interval for problems with the reverse sign configuration (~surprisingly enough, it sometimes works with the wrong signs~ [1]). This PR fixes the issue and adds a basic test for it.

[1] Did not realize that's only the case if one of the edges is the solution already