### PR TITLE
Backport ITP bugfixes from DiffEqBase in high precision contexts

### DIFF
--- a/src/itp.jl
+++ b/src/itp.jl
@@ -125,8 +125,8 @@ function SciMLBase.solve(prob::IntervalNonlinearProblem, alg::ITP,
             fl = yp
         else
             return SciMLBase.build_solution(prob, alg, xp, yps;
-                                            retcode = ReturnCode.Success, left = left,
-                                            right = right)
+                                            retcode = ReturnCode.Success, left = xp,
+                                            right = xp)
         end
         i += 1
         mid = (left + right) / 2

--- a/src/itp.jl
+++ b/src/itp.jl
@@ -80,7 +80,7 @@ function SciMLBase.solve(prob::IntervalNonlinearProblem, alg::ITP,
     n0 = alg.n0
     n_h = ceil(log2(abs(right - left) / (2 * ϵ)))
     mid = (left + right) / 2
-    x_f = (fr * left - fl * right) / (fr - fl)
+    x_f = left + (right - left) * (fl/(fl - fr))
     xt = left
     xp = left
     r = zero(left) #minmax radius
@@ -94,7 +94,7 @@ function SciMLBase.solve(prob::IntervalNonlinearProblem, alg::ITP,
         δ = k1 * (span^k2)
 
         ## Interpolation step ##
-        x_f = (fr * left - fl * right) / (fr - fl)
+        x_f = left + (right - left) * (fl/(fl - fr))
 
         ## Truncation step ##
         σ = sign(mid - x_f)

--- a/test/basictests.jl
+++ b/test/basictests.jl
@@ -540,18 +540,19 @@ for alg in (SimpleNewtonRaphson(), SimpleTrustRegion())
     @test abs.(sol.u) ≈ sqrt.(p)
 end
 
-# Flipped signs test
+# Flipped signs & reversed tsoan test for bracketing algorithms
 f1(u, p) = u * u - p 
 f2(u, p) = p - u * u
 
-for Alg in (Alefeld, Bisection, Falsi, Brent, ITP, Ridder)
-    alg = Alg()
+for alg in (Alefeld(), Bisection(), Falsi(), Brent(), ITP(), Ridder())
     for p ∈ 1:4
         inp1 = IntervalNonlinearProblem(f1, (1.0, 2.0), p)
         inp2 = IntervalNonlinearProblem(f2, (1.0, 2.0), p)
-        sol = solve(inp1, alg)
-        @test abs.(sol.u) ≈ sqrt.(p)
-        sol = solve(inp2, alg)
-        @test abs.(sol.u) ≈ sqrt.(p)
+        inp3 = IntervalNonlinearProblem(f1, (2.0, 1.0), p)
+        inp4 = IntervalNonlinearProblem(f2, (2.0, 1.0), p)
+        @test abs.(solve(inp1, alg).u) ≈ sqrt.(p)
+        @test abs.(solve(inp2, alg).u) ≈ sqrt.(p)
+        @test abs.(solve(inp3, alg).u) ≈ sqrt.(p)
+        @test abs.(solve(inp4, alg).u) ≈ sqrt.(p)
     end
 end

--- a/test/basictests.jl
+++ b/test/basictests.jl
@@ -540,7 +540,7 @@ for alg in (SimpleNewtonRaphson(), SimpleTrustRegion())
     @test abs.(sol.u) ≈ sqrt.(p)
 end
 
-# Flipped signs & reversed tsoan test for bracketing algorithms
+# Flipped signs & reversed tspan test for bracketing algorithms
 f1(u, p) = u * u - p
 f2(u, p) = p - u * u
 


### PR DESCRIPTION
Fix a couple of issues on ITP that we found on https://github.com/SciML/DiffEqBase.jl/pull/917
Specifically:

- Prevent iterations with zero progress (and thus getting stuck in a value until max iters) due to loss of relative precision near the solution
- Allow for reversed tspans

I also extended the bracketing tests to cover cases of `IntervalNonlinearProblem` with a reversed tspan (ie `tspan[2] < tspan[1]`). I am not sure if this is intended behavior; I assume it is since it works for the previous methods and the corresponding problem can be created. If this is not intended, we can remove those tests but I think it should error at `IntervalNonlinearProblem` creation time, then.

Another point: return behaviour is slightly different from the DiffEqBase implementation, where the solution has to fulfill `iszero(f(nextfloat(t_sol))) || f(t_sol) * f(nextfloat(tsol)) < 0.0`. Here, if `f(t) = 0.0` then `t` is returned as the solution, which I guess makes more sense for other purposes.