### PR TITLE
Fix error in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ using SimpleNonlinearSolve, StaticArrays
 f(u,p) = u .* u .- 2
 u0 = @SVector[1.0, 1.0]
 probN = NonlinearProblem{false}(f, u0)
-solver = solve(probN, SimpleNewtonRaphson(), tol = 1e-9)
+solver = solve(probN, SimpleNewtonRaphson(), abstol = 1e-9)
 
 ## Bracketing Methods
 


### PR DESCRIPTION
Used keyword `tol`, changed to `abstol`