### PR TITLE
[WIP] SimpleTrustRegion bug

### DIFF
--- a/src/trustRegion.jl
+++ b/src/trustRegion.jl
@@ -68,7 +68,7 @@ struct SimpleTrustRegion{T, CS, AD, FDT} <: AbstractNewtonAlgorithm{CS, AD, FDT}
         diff_type = Val{:forward},
         max_trust_radius::Real = 0.0,
         initial_trust_radius::Real = 0.0,
-        step_threshold::Real = 0.1,
+        step_threshold::Real = 0.0001,
         shrink_threshold::Real = 0.25,
         expand_threshold::Real = 0.75,
         shrink_factor::Real = 0.25,

--- a/src/trustRegion.jl
+++ b/src/trustRegion.jl
@@ -134,8 +134,8 @@ function SciMLBase.__solve(prob::NonlinearProblem,
     end
 
     fₖ = 0.5 * norm(F)^2
-    H = ∇f * ∇f
-    g = ∇f * F
+    H = ∇f' * ∇f
+    g = ∇f' * F
     shrink_counter = 0
 
     for k in 1:maxiters
@@ -188,8 +188,8 @@ function SciMLBase.__solve(prob::NonlinearProblem,
                 Δ = min(t₂ * Δ, Δₘₐₓ)
             end
             fₖ = fₖ₊₁
-            H = ∇f * ∇f
-            g = ∇f * F
+            H = ∇f' * ∇f
+            g = ∇f' * F
         end
     end
     return SciMLBase.build_solution(prob, alg, x, F; retcode = ReturnCode.MaxIters)


### PR DESCRIPTION
Hey,

I am going over the TR implementation to address https://github.com/SciML/SimpleNonlinearSolve.jl/issues/98. With the current changes, the TR method converges for the MWE  in https://github.com/SciML/SimpleNonlinearSolve.jl/issues/98. I would like to doublecheck some other things to make sure the implementation here consistent with that in NonlinearSolve.jl before I suggest merging. 

Flemming