### PR TITLE
Static GPU compilation of Jacobian

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -13,7 +13,7 @@ steps:
     agents:
       queue: "juliagpu"
       cuda: "*"
-    timeout_in_minutes: 30
+    timeout_in_minutes: 120
     # Don't run Buildkite if the commit message includes the text [skip tests]
     if: build.message !~ /\[skip tests\]/
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SimpleNonlinearSolve"
 uuid = "727e6d20-b764-4bd8-a329-72de5adea6c7"
 authors = ["SciML"]
-version = "1.4.2"
+version = "1.4.3"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"


### PR DESCRIPTION
```julia
using KernelAbstractions, CUDA, NonlinearSolve, StaticArrays

@kernel function parallel_nonlinearsolve_kernel!(result, @Const(prob), @Const(alg))
    i = @index(Global)
    prob_i = remake(prob; u0 = prob.u0[i])
    @inbounds result[i] = solve(prob_i, alg).u
    return nothing
end

function vectorized_solve(prob, alg)
    backend = get_backend(prob.u0)
    result = KernelAbstractions.zeros(backend, prob.u0)
end

@generated function generalized_rosenbrock(x::SVector{N}, p) where {N}
    vals = ntuple(gensym ∘ string, N)
    expr = []
    push!(expr, :($(vals[1]) = oneunit(x[1]) - x[1]))
    for i in 2:N
        push!(expr, :($(vals[i]) = 10.0 * (x[$i] - x[$i - 1] * x[$i - 1])))
    end
    push!(expr, :(@SVector [$(vals...)]))
    return Expr(:block, expr...)
end

u0 = @SVector [@SVector(rand(10)) for _ in 1:16]
prob = NonlinearProblem(generalized_rosenbrock, u0)

backend = CUDABackend()#  get_backend(u0)
result = KernelAbstractions.zeros(backend, eltype(u0), length(u0))

kernel! = parallel_nonlinearsolve_kernel!(backend)
kernel!(result, prob, SimpleNewtonRaphson(; autodiff = AutoForwardDiff(; chunksize = 10));
    ndrange = length(u0))
kernel!(result, prob, SimpleNewtonRaphson(; autodiff = AutoForwardDiff(; chunksize = 10));
    ndrange = length(u0))

kernel!(result, prob, SimpleDFSane(); ndrange = length(u0))

prob_i = remake(prob; u0 = prob.u0[1])

@profview_allocs for i in 1:100000
    solve(prob_i, SimpleNewtonRaphson(; autodiff = AutoForwardDiff(; chunksize = 10)))
end

using AllocCheck

@check_allocs function noalloc_solve(prob, alg)
    return solve(prob, alg)
end

noalloc_solve(prob_i, SimpleNewtonRaphson(; autodiff = AutoForwardDiff(; chunksize = 10)))
```