### PR TITLE
Remove recompile_invalidations

### DIFF
--- a/src/SimpleNonlinearSolve.jl
+++ b/src/SimpleNonlinearSolve.jl
@@ -15,8 +15,8 @@ using DiffResults: DiffResults
 using FastClosures: @closure
 using FiniteDiff: FiniteDiff
 using ForwardDiff: ForwardDiff, Dual
-using LinearAlgebra: LinearAlgebra, I, convert, copyto!, diagind, dot, issuccess, lu,
-                     mul!, norm, transpose
+using LinearAlgebra: LinearAlgebra, I, convert, copyto!, diagind, dot, issuccess, lu, mul!,
+                     norm, transpose
 using MaybeInplace: @bb, setindex_trait, CanSetindex, CannotSetindex
 using Reexport: @reexport
 using SciMLBase: SciMLBase, AbstractNonlinearProblem, IntervalNonlinearProblem,

--- a/src/SimpleNonlinearSolve.jl
+++ b/src/SimpleNonlinearSolve.jl
@@ -1,32 +1,30 @@
 module SimpleNonlinearSolve
 
-using PrecompileTools: @compile_workload, @setup_workload, @recompile_invalidations
+using PrecompileTools: @compile_workload, @setup_workload
 
-@recompile_invalidations begin
-    using ADTypes: ADTypes, AbstractADType, AutoFiniteDiff, AutoForwardDiff,
-                   AutoPolyesterForwardDiff
-    using ArrayInterface: ArrayInterface
-    using ConcreteStructs: @concrete
-    using DiffEqBase: DiffEqBase, AbstractNonlinearTerminationMode,
-                      AbstractSafeNonlinearTerminationMode,
-                      AbstractSafeBestNonlinearTerminationMode, AbsNormTerminationMode,
-                      NONLINEARSOLVE_DEFAULT_NORM
-    using DifferentiationInterface: DifferentiationInterface
-    using DiffResults: DiffResults
-    using FastClosures: @closure
-    using FiniteDiff: FiniteDiff
-    using ForwardDiff: ForwardDiff, Dual
-    using LinearAlgebra: LinearAlgebra, I, convert, copyto!, diagind, dot, issuccess, lu,
-                         mul!, norm, transpose
-    using MaybeInplace: @bb, setindex_trait, CanSetindex, CannotSetindex
-    using Reexport: @reexport
-    using SciMLBase: SciMLBase, AbstractNonlinearProblem, IntervalNonlinearProblem,
-                     NonlinearFunction, NonlinearLeastSquaresProblem, NonlinearProblem,
-                     ReturnCode, init, remake, solve, AbstractNonlinearAlgorithm,
-                     build_solution, isinplace, _unwrap_val
-    using Setfield: @set!
-    using StaticArraysCore: StaticArray, SVector, SMatrix, SArray, MArray, Size
-end
+using ADTypes: ADTypes, AbstractADType, AutoFiniteDiff, AutoForwardDiff,
+               AutoPolyesterForwardDiff
+using ArrayInterface: ArrayInterface
+using ConcreteStructs: @concrete
+using DiffEqBase: DiffEqBase, AbstractNonlinearTerminationMode,
+                  AbstractSafeNonlinearTerminationMode,
+                  AbstractSafeBestNonlinearTerminationMode, AbsNormTerminationMode,
+                  NONLINEARSOLVE_DEFAULT_NORM
+using DifferentiationInterface: DifferentiationInterface
+using DiffResults: DiffResults
+using FastClosures: @closure
+using FiniteDiff: FiniteDiff
+using ForwardDiff: ForwardDiff, Dual
+using LinearAlgebra: LinearAlgebra, I, convert, copyto!, diagind, dot, issuccess, lu,
+                     mul!, norm, transpose
+using MaybeInplace: @bb, setindex_trait, CanSetindex, CannotSetindex
+using Reexport: @reexport
+using SciMLBase: SciMLBase, AbstractNonlinearProblem, IntervalNonlinearProblem,
+                 NonlinearFunction, NonlinearLeastSquaresProblem, NonlinearProblem,
+                 ReturnCode, init, remake, solve, AbstractNonlinearAlgorithm,
+                 build_solution, isinplace, _unwrap_val
+using Setfield: @set!
+using StaticArraysCore: StaticArray, SVector, SMatrix, SArray, MArray, Size
 
 const DI = DifferentiationInterface
 


### PR DESCRIPTION
`@recompile_invalidations` should only be used in very specific scenarios, and this is not one of those scenarios. Also, there are big changes being done with https://github.com/SciML/CommonWorldInvalidations.jl. With that, we only need to `@recompile_invalidations` on a few entry points. In particular, Static.jl, Symbolics.jl, and preferably ForwardDiff.jl and StaticArrays.jl would adopt it too. But this means that in order to handle all of this effectively, in SciML we only need to apply it on Static.jl, Symbolics.jl, and SciMLBase.jl and the whole ecosystem should be fine.

In any case, this library doesn't need it. It shouldn't make a tangible difference in compile times, while it increases precompile times by a lot.
