### PR TITLE
Default ITP parameters update

### DIFF
--- a/src/bracketing/itp.jl
+++ b/src/bracketing/itp.jl
@@ -15,15 +15,21 @@ I. F. D. Oliveira and R. H. C. Takahashi.
 The following keyword parameters are accepted.
 
   - `n₀::Int = 10`, the 'slack'. Must not be negative. When n₀ = 0 the worst-case is
-    identical to that of bisection, but increacing n₀ provides greater oppotunity for
+    identical to that of bisection, but increasing n₀ provides greater opportunity for
     superlinearity.
-  - `scaled_κ₁::Float64 = 0.2`. Must not be negative. The recomended value is `0.2`.
+  - `scaled_κ₁::Float64 = 0.2`. Must not be negative. The recommended value is `0.2`.
     Lower values produce tighter asymptotic behaviour, while higher values improve the
     steady-state behaviour when truncation is not helpful.
   - `κ₂::Real = 2`. Must lie in [1, 1+ϕ ≈ 2.62). Higher values allow for a greater
     convergence rate, but also make the method more succeptable to worst-case performance.
-    In practice, κ=1, 2 seems to work well due to the computational simplicity, as κ₂ is
+    In practice, κ₂=1, 2 seems to work well due to the computational simplicity, as κ₂ is
     used as an exponent in the method.
+
+### Computation of κ₁
+
+In the current implementation, we compute κ₁ = scaled_κ₁·|Δx₀|^(1 - κ₂); this allows κ₁ to
+adapt to the dimension of the problem in order to keep the proposed initial step
+proportional to Δx₀.
 
 ### Worst Case Performance
 
@@ -72,8 +78,8 @@ function SciMLBase.solve(prob::IntervalNonlinearProblem, alg::ITP, args...;
     end
     ϵ = abstol
     #defining variables/cache
-    k1 = alg.scaled_k1 / abs(right - left)
     k2 = alg.k2
+    k1 = alg.scaled_k1 * abs(right - left)^(1 - k2)
     n0 = alg.n0
     n_h = ceil(log2(abs(right - left) / (2 * ϵ)))
     mid = (left + right) / 2

--- a/src/bracketing/itp.jl
+++ b/src/bracketing/itp.jl
@@ -124,10 +124,11 @@ function SciMLBase.solve(prob::IntervalNonlinearProblem, alg::ITP, args...;
         xp <= tmin && (xp = nextfloat(tmin))
         yp = f(xp)
         yps = yp * sign(fr)
-        if yps > 0
+        T0 = zero(yps)
+        if yps > T0
             right = xp
             fr = yp
-        elseif yps < 0
+        elseif yps < T0
             left = xp
             fl = yp
         else

--- a/src/bracketing/itp.jl
+++ b/src/bracketing/itp.jl
@@ -17,13 +17,13 @@ The following keyword parameters are accepted.
   - `n₀::Int = 10`, the 'slack'. Must not be negative. When n₀ = 0 the worst-case is
     identical to that of bisection, but increacing n₀ provides greater oppotunity for
     superlinearity.
-  - `κ₁::Float64 = 0.007`. Must not be negative. The recomended value is `0.2/(x₂ - x₁)`.
+  - `scaled_κ₁::Float64 = 0.2`. Must not be negative. The recomended value is `0.2`.
     Lower values produce tighter asymptotic behaviour, while higher values improve the
     steady-state behaviour when truncation is not helpful.
-  - `κ₂::Real = 1.5`. Must lie in [1, 1+ϕ ≈ 2.62). Higher values allow for a greater
+  - `κ₂::Real = 2`. Must lie in [1, 1+ϕ ≈ 2.62). Higher values allow for a greater
     convergence rate, but also make the method more succeptable to worst-case performance.
-    In practice, κ=1,2 seems to work well due to the computational simplicity, as κ₂ is used
-    as an exponent in the method.
+    In practice, κ=1, 2 seems to work well due to the computational simplicity, as κ₂ is
+    used as an exponent in the method.
 
 ### Worst Case Performance
 
@@ -35,19 +35,19 @@ n½ + `n₀` iterations, where n½ is the number of iterations using bisection
 If `f` is twice differentiable and the root is simple, then with `n₀` > 0 the convergence
 rate is √`κ₂`.
 """
-struct ITP{T} <: AbstractBracketingAlgorithm
-    k1::T
-    k2::T
+struct ITP{T₁, T₂} <: AbstractBracketingAlgorithm
+    scaled_k1::T₁
+    k2::T₂
     n0::Int
-    function ITP(; k1::Real = 0.007, k2::Real = 1.5, n0::Int = 10)
-        k1 < 0 && error("Hyper-parameter κ₁ should not be negative")
+    function ITP(;
+            scaled_k1::T₁ = 0.2, k2::T₂ = 2, n0::Int = 10) where {T₁ <: Real, T₂ <: Real}
+        scaled_k1 < 0 && error("Hyper-parameter κ₁ should not be negative")
         n0 < 0 && error("Hyper-parameter n₀ should not be negative")
         if k2 < 1 || k2 > (1.5 + sqrt(5) / 2)
             throw(ArgumentError("Hyper-parameter κ₂ should be between 1 and 1 + ϕ where \
                                  ϕ ≈ 1.618... is the golden ratio"))
         end
-        T = promote_type(eltype(k1), eltype(k2))
-        return new{T}(k1, k2, n0)
+        return new{T₁, T₂}(scaled_k1, k2, n0)
     end
 end
 
@@ -72,7 +72,7 @@ function SciMLBase.solve(prob::IntervalNonlinearProblem, alg::ITP, args...;
     end
     ϵ = abstol
     #defining variables/cache
-    k1 = alg.k1
+    k1 = alg.scaled_k1 / abs(right - left)
     k2 = alg.k2
     n0 = alg.n0
     n_h = ceil(log2(abs(right - left) / (2 * ϵ)))
@@ -88,7 +88,7 @@ function SciMLBase.solve(prob::IntervalNonlinearProblem, alg::ITP, args...;
     while i <= maxiters
         span = abs(right - left)
         r = ϵ_s - (span / 2)
-        δ = k1 * (span^k2)
+        δ = k1 * ((k2 == 2) ? span^2 : (span^k2))
 
         ## Interpolation step ##
         x_f = left + (right - left) * (fl / (fl - fr))

--- a/src/bracketing/itp.jl
+++ b/src/bracketing/itp.jl
@@ -28,8 +28,7 @@ The following keyword parameters are accepted.
 ### Computation of κ₁
 
 In the current implementation, we compute κ₁ = scaled_κ₁·|Δx₀|^(1 - κ₂); this allows κ₁ to
-adapt to the dimension of the problem in order to keep the proposed initial step
-proportional to Δx₀.
+adapt to the length of the interval and keep the proposed steps proportional to Δx.
 
 ### Worst Case Performance
 


### PR DESCRIPTION
Address #108 and update default ITP parameters to the ones in the paper.

## Additional context

Additionally, the coefficient `κ₁` has been replaced in the ITP struct by a scale-invariant version that is dimensionally coherent. In the original ITP paper, they fix κ₁ so that the first scaled step is 20% of the interval, but for their test functions in the (-1,1) interval. This produces an algorithm that is not scale-invariant: just resizing the span (while appropriately "stretching" the corresponding function) can improve or degrade performance: see Fig. 1, which evaluates it on the test functions from the ITP paper:

![current](https://github.com/user-attachments/assets/318a699c-031f-4371-b60b-e5121e51a309)

With the proposed changes in this PR (using a value that is equivalent to the "20% of the span" rule of thumb), this pattern disappears:

![pr](https://github.com/user-attachments/assets/a1410d54-cbba-45b4-8798-2729c2e2bd09)

Code:

```julia
using SimpleNonlinearSolve, SpecialFunctions

normpdf(z::Number) = exp(-abs2(z)/2) * (1 / sqrt(2π))
ϕ(x) = normpdf(x)
Φ(x) = erfc(x / sqrt(2))/2

function count_evals(f, r)
    function g(x, p)
        p[1] += 1
        f(x / r)
    end
    p = [0]
    prob = IntervalNonlinearProblem{false}(g, (-r, r), p)
    sol = solve(prob, ITP(); abstol = 1e-9 * r)
    p[1]
end

# Well-behaved functions from ITP paper
f_wb = (
    x -> x * exp(x) - 1, 
    x -> tan(x - 0.1), 
    x -> sin(x) + 0.5,
    x -> 4x^5 + x^2 + 1, 
    x -> x + x^10 - 1, 
    x -> π^x - exp(1),
    x -> log(abs(x - 10 / 9)), 
    x -> 1 / 3 + sign(x) * abs(x)^(1 / 3) + x^3,
    x -> 10^(-3) + sum(sin(0.5π * i^3 * x)/(π*i^3) for i ∈ 1:10),
    x -> (x + 2/3)/(x + 101/100), 
    x -> Φ(x-1) - √(2)/4, 
    x -> ϕ(x-1) - √(2)/4
)

# Ill-behaved functions from ITP paper (selection)
f_ib = (
    x -> (1e6x - 1)^3,
    x -> exp(x)*(1e6x - 1)^3,
    x -> (x - 1/3)^2 * atan(x - 1/3),
    x -> sign(3x+1)*(1 - sqrt(1 - (3x + 1)^2 / 9^2)),
    x -> ifelse(x > (1 - 1e6)/1e6, (1 + 1e6)/1e6, 0.0) - 1, # notation ?
    x -> ifelse(x == 1/21, 0.0, 1/(21x - 1)),
    x -> (0.5x)^2 + ceil(0.5x) - 0.5,
    x -> ceil(10x - 1) + 0.5,
    x -> x + sin(1e6x)/10 + 1e-3,
    # x -> ifelse(x > -1, 1 + sin(), 0.0)    
)

f_all = (f_wb..., f_ib...)
scales_list = [1e-12, 1e-9, 1e-6, 1e-3, 1.0, 1e3, 1e6, 1e9, 1e12]
l = [[count_evals(f, s) for s ∈ scales_list]  for f ∈ f_all]

begin
    using Plots
    p = Plots.plot(scales_list, l, xaxis=:log, title="PR", 
    xlabel="Scale factor", ylabel="Function evaluations", legend=false)
end
```

## Checklist

- [x] Appropriate tests were added (does not apply)
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  