### PR TITLE
Return InitialFailure from bracketing methods if not enclosing interval

### DIFF
--- a/src/bracketing/bisection.jl
+++ b/src/bracketing/bisection.jl
@@ -39,6 +39,12 @@ function SciMLBase.solve(prob::IntervalNonlinearProblem, alg::Bisection,
             prob, alg, right, fr; retcode = ReturnCode.ExactSolutionRight, left, right)
     end
 
+    if sign(fl) == sign(fr)
+        @warn "The interval is not an enclosing interval, opposite signs at the boundaries are required."
+        return build_solution(
+            prob, alg, left, fl; retcode = ReturnCode.InitialFailure, left, right)
+    end
+
     i = 1
     if !iszero(fr)
         while i < maxiters

--- a/src/bracketing/brent.jl
+++ b/src/bracketing/brent.jl
@@ -26,6 +26,12 @@ function SciMLBase.solve(prob::IntervalNonlinearProblem, alg::Brent, args...;
             prob, alg, right, fr; retcode = ReturnCode.ExactSolutionRight, left, right)
     end
 
+    if sign(fl) == sign(fr)
+        @warn "The interval is not an enclosing interval, opposite signs at the boundaries are required."
+        return build_solution(
+            prob, alg, left, fl; retcode = ReturnCode.InitialFailure, left, right)
+    end
+
     if abs(fl) < abs(fr)
         c = right
         right = left

--- a/src/bracketing/falsi.jl
+++ b/src/bracketing/falsi.jl
@@ -25,6 +25,12 @@ function SciMLBase.solve(prob::IntervalNonlinearProblem, alg::Falsi, args...;
             prob, alg, right, fr; retcode = ReturnCode.ExactSolutionRight, left, right)
     end
 
+    if sign(fl) == sign(fr)
+        @warn "The interval is not an enclosing interval, opposite signs at the boundaries are required."
+        return build_solution(
+            prob, alg, left, fl; retcode = ReturnCode.InitialFailure, left, right)
+    end
+
     # Regula Falsi Steps
     i = 0
     if !iszero(fr)

--- a/src/bracketing/itp.jl
+++ b/src/bracketing/itp.jl
@@ -75,6 +75,13 @@ function SciMLBase.solve(prob::IntervalNonlinearProblem, alg::ITP, args...;
         return build_solution(
             prob, alg, right, fr; retcode = ReturnCode.ExactSolutionRight, left, right)
     end
+
+    if sign(fl) == sign(fr)
+        @warn "The interval is not an enclosing interval, opposite signs at the boundaries are required."
+        return build_solution(
+            prob, alg, left, fl; retcode = ReturnCode.InitialFailure, left, right)
+    end
+
     ϵ = abstol
     #defining variables/cache
     k2 = alg.k2

--- a/src/bracketing/ridder.jl
+++ b/src/bracketing/ridder.jl
@@ -25,6 +25,12 @@ function SciMLBase.solve(prob::IntervalNonlinearProblem, alg::Ridder, args...;
             prob, alg, right, fr; retcode = ReturnCode.ExactSolutionRight, left, right)
     end
 
+    if sign(fl) == sign(fr)
+        @warn "The interval is not an enclosing interval, opposite signs at the boundaries are required."
+        return build_solution(
+            prob, alg, left, fl; retcode = ReturnCode.InitialFailure, left, right)
+    end
+
     xo = oftype(left, Inf)
     i = 1
     if !iszero(fr)


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Fixes SciML/NonlinearSolve.jl#452
